### PR TITLE
Fix grunt test alias

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -80,6 +80,5 @@ module.exports = ( grunt ) ->
     ]
 
     grunt.registerTask "test", [
-        "clean"
         "parker"
     ]


### PR DESCRIPTION
Hi there. Looks like the `clean` task was never implemented? It's causing `test` to fail, so I've removed it in this PR since the `parker` task will overwrite `report.md` every time it runs (I'm guessing that's the only thing that could require `clean`ing?)