### PR TITLE
Update parker to fix gh-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "parker": "0.0.9"
+    "parker": "0.0.10"
   }
 }


### PR DESCRIPTION
Cannot install using parker 0.0.9. parker has been updated to 0.0.10. See https://github.com/katiefenn/parker/issues/44